### PR TITLE
[OPS-212] Chart Museum Push Workflow Template

### DIFF
--- a/workflow-templates/chartmuseum-push.properties.json
+++ b/workflow-templates/chartmuseum-push.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "ChartMuseum Push",
+    "description": "Push a chart to a chartmuseum repository",
+    "iconName": "helm",
+    "categories": [
+        "HelmCharts"
+    ],
+    "filePatterns": [
+        ".*\\.yaml$"
+    ]
+}

--- a/workflow-templates/chartmuseum-push.yaml
+++ b/workflow-templates/chartmuseum-push.yaml
@@ -1,4 +1,4 @@
-name: Build dockerimage and package helmchart, push to ECR
+name: Push chart to harbor chartmuseum
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
     tags:
       - "*.*.*"
 jobs:
-  docker:
+  chartmuseum-push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,25 +17,16 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.4.0
-      - name: Set current epoch time as env variable
-        run: echo "NOW=$(date +%s)" >> $GITHUB_ENV
-      - name: Echo current date
-        run: echo $NOW
       - name: Install chart museum push extension
         run: helm plugin install https://github.com/chartmuseum/helm-push.git
-      - name: Bump up chart version
-        run: |
-          helm release chart --skip-application-version
-          cat chart/Chart.yaml
       - name: package helm chart
         run: |
           helm package chart
-          export chartVersion=$(helm release chart --print-computed-version)
-          export helmpackage=${{ github.event.repository.name }}-$chartVersion
       - name: push helm package
         env:
-          CHARTMUSEUM_URL: ${{ secrets.CHARTMUSEUM_URL }}
+          HARBOR_BASEURL: ${{ secrets.HARBOR_BASEURL }} 
+          HARBOR_PROJECT: ${{ secrets.HARBOR_PROJECT }}
           CHARTMUSEUM_USER: ${{ secrets.CHARTMUSEUM_USER }}
           CHARTMUSEUM_PASSWORD: ${{ secrets.CHARTMUSEUM_PASSWORD }}
         run: |
-          helm cm-push chart $CHARTMUSEUM_URL -u $CHARTMUSEUM_USER -p $CHARTMUSEUM_PASSWORD
+          helm cm-push chart $HARBOR_BASEURL/chartrepo/$HARBOR_PROJECT -u $CHARTMUSEUM_USER -p $CHARTMUSEUM_PASSWORD 

--- a/workflow-templates/chartmuseum-push.yaml
+++ b/workflow-templates/chartmuseum-push.yaml
@@ -1,0 +1,41 @@
+name: Build dockerimage and package helmchart, push to ECR
+
+on:
+  push:
+    branches:
+      - "stable"
+      - "main"
+    tags:
+      - "*.*.*"
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+      - name: Set current epoch time as env variable
+        run: echo "NOW=$(date +%s)" >> $GITHUB_ENV
+      - name: Echo current date
+        run: echo $NOW
+      - name: Install chart museum push extension
+        run: helm plugin install https://github.com/chartmuseum/helm-push.git
+      - name: Bump up chart version
+        run: |
+          helm release chart --skip-application-version
+          cat chart/Chart.yaml
+      - name: package helm chart
+        run: |
+          helm package chart
+          export chartVersion=$(helm release chart --print-computed-version)
+          export helmpackage=${{ github.event.repository.name }}-$chartVersion
+      - name: push helm package
+        env:
+          CHARTMUSEUM_URL: ${{ secrets.CHARTMUSEUM_URL }}
+          CHARTMUSEUM_USER: ${{ secrets.CHARTMUSEUM_USER }}
+          CHARTMUSEUM_PASSWORD: ${{ secrets.CHARTMUSEUM_PASSWORD }}
+        run: |
+          helm cm-push chart $CHARTMUSEUM_URL -u $CHARTMUSEUM_USER -p $CHARTMUSEUM_PASSWORD


### PR DESCRIPTION
### Summary
Template to push chart to chartmuseum on a Harbor instance.

### Testing
- Create a project in harbor
- Create a robot account in that project
- Configure the following secrets on a repo with a helm chart in the `chart` folder:
 
          HARBOR_BASEURL: this should be the base url for your Harbor instance with no trailing slash (ie `https://foo.harbor.hypergiant.com`) 
          HARBOR_PROJECT: the slug for the project in Harbor
          CHARTMUSEUM_USER: the name of the robot account
          CHARTMUSEUM_PASSWORD: the token for the robot account
- Install the template on the repo
- Push to the stable branch
 ### Ticket
https://gohypergiant.atlassian.net/browse/OPS-212