### PR TITLE
fix syntax on secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,12 +2,6 @@ name: Secret Scan
 
 on:
   workflow_call:
-
-jobs:
-  secret-scan:
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
     inputs:
       exclude_path:
         required: false
@@ -15,6 +9,12 @@ jobs:
       include_path:
         required: false
         default: ''
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
 
     steps:
       -


### PR DESCRIPTION
I think inputs needs to be a child of `on.workflow_call:`